### PR TITLE
Fix regex

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -19,6 +19,6 @@ class Govet(Linter):
 
     syntax = ('go', 'gosublime-go')
     cmd = ('go', 'tool', 'vet')
-    regex = r'^.+:(?P<line>\d+):\s+(?P<message>.+)'
+    regex = r'^.+:(?P<line>\d+):\d+:\s+(?P<message>.+)'
     tempfile_suffix = 'go'
     error_stream = util.STREAM_STDERR


### PR DESCRIPTION
Old regex was using reading lint code instead of line number.

Expected lint msg
{go_file_path}:{line_number}:{error_code}: {message}
