### PR TITLE
Use named capture group "col" for column number

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -19,6 +19,6 @@ class Govet(Linter):
 
     syntax = ('go', 'gosublime-go')
     cmd = ('go', 'tool', 'vet')
-    regex = r'^.+:(?P<line>\d+):\d+:\s+(?P<message>.+)'
+    regex = r'^.+:(?P<line>\d+):(?P<col>\d+):\s+(?P<message>.+)'
     tempfile_suffix = 'go'
     error_stream = util.STREAM_STDERR

--- a/linter.py
+++ b/linter.py
@@ -14,7 +14,6 @@ from SublimeLinter.lint import Linter, util
 
 
 class Govet(Linter):
-
     """Provides an interface to go vet."""
 
     syntax = ('go', 'gosublime-go')

--- a/linter.py
+++ b/linter.py
@@ -19,6 +19,6 @@ class Govet(Linter):
 
     syntax = ('go', 'gosublime-go')
     cmd = ('go', 'tool', 'vet')
-    regex = r'^.+:(?P<line>\d+):\s+(?P<message>.+)'
+    regex = r'^.+:(?P<line>\d+):\d+:\s+(?P<message>.+)'
     tempfile_suffix = 'go'
     error_stream = util.STREAM_STDERR


### PR DESCRIPTION
As I commented [here][1] in #4, it might be even better to use the named capture group for column number.  This gives a nicer red highlight on the character within an error line reported by `go tool vet`.

[1]: https://github.com/sirreal/SublimeLinter-contrib-govet/pull/4#issuecomment-356491326
  